### PR TITLE
Port geändert

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,10 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # App-Code kopieren
 COPY app/ app/
-COPY dependencies/ dependencies/
+#COPY dependencies/ dependencies/
 
 # Port
-EXPOSE 5000
+EXPOSE 3333
 
 # Startbefehl
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "5000"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "3333"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,9 @@ services:
     ports:
       - "3333:3333"
     environment:
-      - BASE_PATH=/TV Shows
-      - VALID_EXT=[".mp4",".mkv",".avi"]
-      - TMDB_API_KEY=e3ee010a10084bde17623ff3f994145a
+      - "BASE_PATH=/tvshows"
+      - "VALID_EXT=[\".mp4\",\".mkv\",\".avi\"]"
+      - "TMDB_API_KEY=e3ee010a10084bde17623ff3f994145a"
     volumes:
       - ./dependencies/.env:/app/dependencies/.env:ro
-      - /BASE_PATH:/tvshows    
+      - ./tvshows:/tvshows


### PR DESCRIPTION
This pull request updates the Docker and Docker Compose configurations to change the application's port, adjust environment variable formatting, and improve volume mounting. These changes help standardize the deployment setup and make it more robust.

**Docker configuration updates:**

- Changed the exposed port in the `Dockerfile` from `5000` to `3333` and updated the `CMD` to use port `3333` for running the `uvicorn` server.
- Commented out the `COPY dependencies/ dependencies/` line in the `Dockerfile`, possibly to avoid copying unnecessary files or due to a change in how dependencies are managed.

**Docker Compose improvements:**

- Updated the `BASE_PATH` environment variable to use `/tvshows` instead of `/TV Shows`, and reformatted the `VALID_EXT` and `TMDB_API_KEY` environment variables for better compatibility.
- Changed the volume mount from `/BASE_PATH:/tvshows` to `./tvshows:/tvshows` for a more predictable and portable local development setup.